### PR TITLE
add connect_timeout:60

### DIFF
--- a/Transport/MailgunTransport.php
+++ b/Transport/MailgunTransport.php
@@ -75,6 +75,7 @@ class MailgunTransport extends Transport
                 'message' => new PostFile('message', $message->toString()),
             ];
         }
+        $options['connect_timeout'] = 60;
 
         $this->client->post($this->url, $options);
 

--- a/Transport/MandrillTransport.php
+++ b/Transport/MandrillTransport.php
@@ -53,6 +53,7 @@ class MandrillTransport extends Transport
         } else {
             $options = ['body' => $data];
         }
+        $options['connect_timeout'] = 60;
 
         $this->client->post('https://mandrillapp.com/api/1.0/messages/send-raw.json', $options);
 

--- a/Transport/SparkPostTransport.php
+++ b/Transport/SparkPostTransport.php
@@ -58,6 +58,7 @@ class SparkPostTransport extends Transport
                     'subject' => $message->getSubject(),
                 ],
             ],
+            'connect_timeout' => 60,
         ];
 
         $this->client->post('https://api.sparkpost.com/api/v1/transmissions', $options);


### PR DESCRIPTION
set connection timeout for drivers that use GuzzleHttp to send request
GuzzleHttp Use 0 to wait indefinitely (the default behavior) for connection timeout and that's really bad for background jobs like queue
it could cause infinite loops..
